### PR TITLE
Update mosquitto.conf

### DIFF
--- a/04-MQTT/mosquitto/mosquitto.conf
+++ b/04-MQTT/mosquitto/mosquitto.conf
@@ -4,3 +4,4 @@ protocol websockets
 persistence true
 persistence_location /mosquitto/data/
 log_dest file /mosquitto/log/mosquitto.log
+allow_anonymous true


### PR DESCRIPTION
Dear Koen,

As of Mosquito 2.0 : allow_anonymous now defaults to false - so for insecure connections it needs to be set to true.  Spend my afternoon figuring this out :)

kind regards,
Diederik